### PR TITLE
Missing dates not compared to lower & upper bounds

### DIFF
--- a/R/checkDate.R
+++ b/R/checkDate.R
@@ -7,9 +7,9 @@
 #' @templateVar fn Atmoic
 #' @template x
 #' @param lower [\code{\link[base]{Date}}]\cr
-#'  All dates in \code{x} must be after this date. Comparison is done via \code{\link[base]{Ops.Date}}.
+#'  All non-missing dates in \code{x} must be after this date. Comparison is done via \code{\link[base]{Ops.Date}}.
 #' @param upper [\code{\link[base]{Date}}]\cr
-#'  All dates in \code{x} must be before this date. Comparison is done via \code{\link[base]{Ops.Date}}.
+#'  All non-missing dates in \code{x} must be before this date. Comparison is done via \code{\link[base]{Ops.Date}}.
 #' @template null.ok
 #' @inheritParams checkVector
 #' @template checker
@@ -33,7 +33,7 @@ checkDateBounds = function(x, lower, upper) {
     lower = as.Date(lower, origin = "1970-01-01")
     if (length(lower) != 1L || is.na(lower))
       stop("Argument 'lower' must be a single (non-missing) date")
-    if (any(x < lower))
+    if (any(x[!is.na(x)] < lower))
       return(sprintf("Date must be >= %s", lower))
   }
 
@@ -41,7 +41,7 @@ checkDateBounds = function(x, lower, upper) {
     upper = as.Date(upper, origin = "1970-01-01")
     if (length(upper) != 1L || is.na(upper))
       stop("Argument 'upper' must be a single (non-missing) date")
-    if (any(x > upper))
+    if (any(x[!is.na(x)] > upper))
       return(sprintf("Date must be <= %s", upper))
   }
   return(TRUE)

--- a/man/checkDate.Rd
+++ b/man/checkDate.Rd
@@ -43,10 +43,10 @@ expect_date(x, lower = NULL, upper = NULL, any.missing = TRUE,
 Object to check.}
 
 \item{lower}{[\code{\link[base]{Date}}]\cr
-All dates in \code{x} must be after this date. Comparison is done via \code{\link[base]{Ops.Date}}.}
+All non-missing dates in \code{x} must be after this date. Comparison is done via \code{\link[base]{Ops.Date}}.}
 
 \item{upper}{[\code{\link[base]{Date}}]\cr
-All dates in \code{x} must be before this date. Comparison is done via \code{\link[base]{Ops.Date}}.}
+All non-missing dates in \code{x} must be before this date. Comparison is done via \code{\link[base]{Ops.Date}}.}
 
 \item{any.missing}{[\code{logical(1)}]\cr
 Are vectors with missing values allowed? Default is \code{TRUE}.}

--- a/tests/testthat/test_checkDate.R
+++ b/tests/testthat/test_checkDate.R
@@ -30,3 +30,39 @@ test_that("checkDate", {
 
   expect_error(assertDate(letters, unique = TRUE), "character")
 })
+
+test_that("NAs are ignored for dates' lower-bound", {
+  # Define and test a nomal date vector, and an empty date vector.
+  d <- as.Date(c("2015-01-01", "2016-01-01", NA_character_, "2017-01-01"))
+  empty <- as.Date(character(0))
+
+  # Bounds pass/fail appropriately when missing values are legal.
+  expect_true( testDate(d    , lower = "1980-01-01", any.missing = TRUE ))
+  expect_false(testDate(d    , lower = "2016-01-01", any.missing = TRUE ))
+
+  # Bounds are ignored when missing values are illegal (and the vector contains missing values).
+  expect_false(testDate(d    , lower = "1980-01-01", any.missing = FALSE))
+  expect_false(testDate(d    , lower = "2016-01-01", any.missing = FALSE))
+
+  # Zero-length dates never fail with a lower bound.
+  expect_true( testDate(empty, lower  ="2030-01-01", any.missing = TRUE ))
+  expect_true( testDate(empty, lower  ="2030-01-01", any.missing = FALSE))
+})
+
+test_that("NAs are ignored for dates' upper-bound", {
+  # Define and test a nomal date vector, and an empty date vector.
+  d <- as.Date(c("2015-01-01", "2016-01-01", NA_character_, "2017-01-01"))
+  empty <- as.Date(character(0))
+
+  # Bounds pass/fail appropriately when missing values are legal.
+  expect_true( testDate(d    , upper = "2020-01-01", any.missing = TRUE ))
+  expect_false(testDate(d    , upper = "2016-01-01", any.missing = TRUE ))
+
+  # Bounds are ignored when missing values are illegal (and the vector contains missing values).
+  expect_false(testDate(d    , upper = "2020-01-01", any.missing = FALSE))
+  expect_false(testDate(d    , upper = "2016-01-01", any.missing = FALSE))
+
+  # Zero-length dates never fail with a upper bound.
+  expect_true( testDate(empty, upper = "2000-01-01", any.missing = FALSE))
+  expect_true( testDate(empty, upper = "2000-01-01", any.missing = FALSE))
+})

--- a/tests/testthat/test_checkDate.R
+++ b/tests/testthat/test_checkDate.R
@@ -35,6 +35,7 @@ test_that("NAs are ignored for dates' lower-bound", {
   # Define and test a nomal date vector, and an empty date vector.
   d <- as.Date(c("2015-01-01", "2016-01-01", NA_character_, "2017-01-01"))
   empty <- as.Date(character(0))
+  nas <- as.Date(NA_character_, NA_character_, NA_character_)
 
   # Bounds pass/fail appropriately when missing values are legal.
   expect_true( testDate(d    , lower = "1980-01-01", any.missing = TRUE ))
@@ -44,15 +45,20 @@ test_that("NAs are ignored for dates' lower-bound", {
   expect_false(testDate(d    , lower = "1980-01-01", any.missing = FALSE))
   expect_false(testDate(d    , lower = "2016-01-01", any.missing = FALSE))
 
-  # Zero-length dates never fail with a lower bound.
+  # Zero-length date vectors never fail with a lower bound.
   expect_true( testDate(empty, lower  ="2030-01-01", any.missing = TRUE ))
   expect_true( testDate(empty, lower  ="2030-01-01", any.missing = FALSE))
+
+  # NA date vectors
+  expect_true( testDate(nas  , lower  ="2030-01-01", any.missing = TRUE ))
+  expect_false(testDate(nas  , lower  ="2030-01-01", any.missing = FALSE))
 })
 
 test_that("NAs are ignored for dates' upper-bound", {
   # Define and test a nomal date vector, and an empty date vector.
   d <- as.Date(c("2015-01-01", "2016-01-01", NA_character_, "2017-01-01"))
   empty <- as.Date(character(0))
+  nas <- as.Date(NA_character_, NA_character_, NA_character_)
 
   # Bounds pass/fail appropriately when missing values are legal.
   expect_true( testDate(d    , upper = "2020-01-01", any.missing = TRUE ))
@@ -62,7 +68,11 @@ test_that("NAs are ignored for dates' upper-bound", {
   expect_false(testDate(d    , upper = "2020-01-01", any.missing = FALSE))
   expect_false(testDate(d    , upper = "2016-01-01", any.missing = FALSE))
 
-  # Zero-length dates never fail with a upper bound.
+  # Zero-length date vectors never fail with a upper bound.
   expect_true( testDate(empty, upper = "2000-01-01", any.missing = FALSE))
   expect_true( testDate(empty, upper = "2000-01-01", any.missing = FALSE))
+
+  # NA date vectors
+  expect_true( testDate(nas  , lower  ="2030-01-01", any.missing = TRUE ))
+  expect_false(testDate(nas  , lower  ="2030-01-01", any.missing = FALSE))
 })


### PR DESCRIPTION
I frequently want to check the bounds of nonmissing cells (in date vectors with some missingness). 
 I modeled these modifications after #106 and c6763481c15625ebf23ebbe1380a5c6ac7163a88