### PR TITLE
Do not evaluate code chunk in tinytest.Rmd

### DIFF
--- a/vignettes/tinytest.Rmd
+++ b/vignettes/tinytest.Rmd
@@ -23,7 +23,7 @@ Quick summary:
 
 1. Edit your `DESCRIPTION` and add `checkmate` to `Suggests` unless it is already listed in `Imports` for its assertions.
 2. In **each** test file which calls an expectation from `checkmate`, you must include the following lines at the beginning of the file:
-    ```{r}
+    ```{r,eval=FALSE}
     library("tinytest")
     library("checkmate")
     using("checkmate")


### PR DESCRIPTION
With this change, the tinytest package is not required to build the vignette. The relevant code chuck serves only demonstration purposes, so we do not loose anything if it is not evaluated. 