### PR TITLE
qassertm: qassert for many at once

### DIFF
--- a/R/qassertm.R
+++ b/R/qassertm.R
@@ -1,0 +1,25 @@
+#' @title Quick checks for multiple variable=rule enumerated as arguments
+#'
+#' @description
+#' Ergonomic wraper for \code{\link{qassert}} to check multiple variable=rule pairs
+#'
+#' @param ... [\code{var.name}=[\code{character}]]\cr
+#'   Any number of named arguments like var.name=rule\cr
+#'   See details of \code{\link{qtest}} for rule explanation.
+#' @template var.name
+#' @return See \code{\link{qassert}}.
+#' @seealso \code{\link{qtest}}, \code{\link{qassert}}
+#' @useDynLib checkmate
+#' @export
+#' @examples
+#' x=1:10; y=TRUE
+#' qassertm(x="i+", y="b")
+#'
+#' with(data.frame(a=1:26,b=letters), qassertm(a="i+", b="s"))
+qassertm <- function(...) {
+   in_args <- list(...)
+   for (v in names(in_args))
+      eval(substitute(qassert(x, spec),
+                      list(x=as.name(v), spec=in_args[[v]])),
+           envir=parent.frame())
+}

--- a/tests/testthat/test_qassertm.R
+++ b/tests/testthat/test_qassertm.R
@@ -1,0 +1,25 @@
+context("qassertm")
+
+xb = logical(10)
+xi = integer(10)
+xr = double(10)
+
+test_that("fail on any, report first", {
+  # none
+  expect_error(qassertm(), NA)
+  # one
+  expect_error(qassertm(xb="b"), NA)
+  # many
+  expect_error(qassertm(xb="l"),
+               regexp = "'xb' .*'list', not 'logical'")
+
+  expect_error(qassertm(xb="b", xi="i", xr="r"), NA)
+  expect_error(qassertm(xb="b", xi="l", xr="r"),
+               regexp = "'xi' .*'list', not 'integer'")
+  expect_error(qassertm(xb="b", xi="i", xr="b"),
+               regexp = "'xr' .*logical', not 'double'")
+
+  # two wrong. only reports first
+  expect_error(qassertm(xb="b", xi="l", xr="b"),
+               regexp = "'xi' .*'list', not 'integer'")
+})


### PR DESCRIPTION
I was looking for a way to condense
```
function(x,y,z){
  qassert(x='n')
  qassert(y='b')
  qassert(z='s')
}
```
and came up with
```
funtion(x,y,z) { qassertm(x='n', y='b', z='s') }
```

I'm not sure if this is generally helpful (#228) or if I missed a more idiomatic way to run multiple checks. Happy to see the request ["ruthlessly closed"](https://www.jeffgeerling.com/blog/2022/burden-open-source-maintainer) if fails on either front!