### PR TITLE
`matchArg` asserts `.var.name` and retrieves `choices` from formals when missing

### DIFF
--- a/R/matchArg.R
+++ b/R/matchArg.R
@@ -18,20 +18,34 @@
 #' @examples
 #' matchArg("k", choices = c("kendall", "pearson"))
 matchArg = function(x, choices, several.ok = FALSE, .var.name = vname(x), add = NULL) {
+  if (missing(choices)) {
+    formal.args <- formals(sys.function(sysP <- sys.parent()))
+    formal_choices <- eval(formal.args[[as.character(substitute(x))]],
+                    envir = sys.frame(sysP))
+    if (!is.null(formal_choices)) {
+      choices <- formal_choices
+    }
+  }
+
   assertCharacter(choices, min.len = 1L)
   assertFlag(several.ok)
+  assertString(.var.name)
 
   if (several.ok) {
     if (identical(x, choices))
       return(x)
     assertCharacter(x, min.len = 1L, .var.name = .var.name, add = add)
-    x = choices[pmatch(x, choices, nomatch = 0L, duplicates.ok = TRUE)]
+    selected_x = choices[pmatch(x, choices, nomatch = 0L, duplicates.ok = TRUE)]
+    if (length(selected_x) > 0)
+      x <- selected_x
     assertSubset(x, choices, empty.ok = FALSE, .var.name = .var.name, add = add)
   } else {
     if (identical(x, choices))
       return(x[1L])
     assertCharacter(x, len = 1L, .var.name = .var.name, add = add)
-    x = choices[pmatch(x, choices, nomatch = 0L, duplicates.ok = FALSE)]
+    selected_x = choices[pmatch(x, choices, nomatch = 0L, duplicates.ok = FALSE)]
+    if (length(selected_x) > 0)
+      x <- selected_x
     assertChoice(x, choices, .var.name = .var.name, add = add)
   }
   x

--- a/tests/testthat/test_matchArg.R
+++ b/tests/testthat/test_matchArg.R
@@ -16,3 +16,12 @@ test_that("matchArg", {
   expect_error(matchArg(x[1:2], choices), "length")
   expect_error(matchArg(x[0], choices), "length 0")
 })
+
+test_that("matchArg detect formals when called within a function", {
+  fun <- function(x = c("pearson", "kendall", "spearman")) {
+    matchArg(x)
+  }
+
+  expect_error(fun("another"), "Must be element")
+  expect_equal(fun("spearman"), "spearman")
+})


### PR DESCRIPTION
Closes #251 

### Changes description

- Asserts `.var.name` which corrects #251 
- Better matches `match.arg` by inferring choices when called from a function