### PR TITLE
docs: enable bootstrap 5 and light switch for pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,1 +1,5 @@
 url: https://mllg.github.io/checkmate/
+
+template:
+  bootstrap: 5
+  light-switch: true


### PR DESCRIPTION
Enable bootstrap 5 template for search and better accessibility