### PR TITLE
Fix testing for NA_REAL (fixes #258)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Fast and Versatile Argument Checks
 Description: Tests and assertions to perform frequent argument checks. A
     substantial part of the package was written in C to minimize any worries
     about execution time overhead.
-Version: 2.3.1
+Version: 2.3.2
 Authors@R: c(
     person("Michel", "Lang", NULL, "michellang@gmail.com",
       role = c("cre", "aut"), comment = c(ORCID = "0000-0001-9754-0393")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # Version 2.3.1
+* Fixed a sortedness check bug for numeric vectors with NAs (#258).
+
+# Version 2.3.1
 * Fixed a sprintf format string for long integers.
 
 # Version 2.3.0

--- a/src/helper.c
+++ b/src/helper.c
@@ -84,7 +84,7 @@ R_xlen_t attribute_hidden as_length(SEXP x, const char *vname) {
             return (R_xlen_t) xi;
         case REALSXP:;
             double xr = REAL_RO(x)[0];
-            if (xr == NA_REAL)
+            if (ISNA(xr))
                 error("Argument '%s' may not be missing", vname);
             if (xr < 0)
                 error("Argument '%s' must be >= 0", vname);

--- a/src/is_sorted.c
+++ b/src/is_sorted.c
@@ -31,10 +31,10 @@ static Rboolean is_sorted_double(SEXP x) {
     R_xlen_t i = 0;
     const R_xlen_t n = xlength(x);
     const double * const xr = REAL_RO(x);
-    while(i < n && xr[i] == NA_REAL) i++;
+    while(i < n && ISNA(xr[i])) i++;
 
     for (R_xlen_t j = i + 1; j < n; j++) {
-        if (xr[j] != NA_REAL) {
+        if (!ISNA(xr[j])) {
             if (xr[i] > xr[j])
                 return FALSE;
             i = j;

--- a/tests/testthat/test_checkNumeric.R
+++ b/tests/testthat/test_checkNumeric.R
@@ -71,6 +71,8 @@ test_that("sorted works", {
     else
       expect_true(grepl("sorted", checkNumeric(xu, sorted = TRUE), fixed = TRUE))
   }
+  ## see https://github.com/mllg/checkmate/issues/258
+  expect_true(grepl("sorted", checkNumeric(c(3, NA, 2), sorted = TRUE), fixed = TRUE))
 })
 
 test_that("names check works", {


### PR DESCRIPTION
As per the [official docs](https://cran.r-project.org/doc/manuals/R-exts.html#Missing-and-special-values-1), `NA_REAL` shall be tested with the `ISNA` macro.

This PR replaces all `== NA_REAL` idioms in the code base with `ISNA`. A new unit test has been added which fails without the current fix, and passes after the fix.