### PR TITLE
Add check for data.table installation

### DIFF
--- a/tests/testthat/test_checkDataTable.R
+++ b/tests/testthat/test_checkDataTable.R
@@ -58,6 +58,8 @@ test_that("list columns", {
 })
 
 test_that("nrow for null data tables", {
+  skip_if_not_physically_installed("data.table")
+
   # c.f. https://github.com/Rdatatable/data.table/issues/3149
   M = matrix(1:3, nrow = 3)
   M = M[, integer(0)]


### PR DESCRIPTION
Found in the other test_that() units here, missing from this 3rd