### PR TITLE
fix: all_missing for complex numbers

### DIFF
--- a/src/all_missing.c
+++ b/src/all_missing.c
@@ -47,7 +47,7 @@ Rboolean attribute_hidden all_missing_complex(SEXP x) {
     const Rcomplex * xp = COMPLEX_RO(x);
     const Rcomplex * const xe = xp + xlength(x);
     for (; xp != xe; xp++) {
-        if (!ISNAN((*xp).r) || !ISNAN((*xp).i))
+        if (!ISNAN((*xp).r) && !ISNAN((*xp).i))
             return FALSE;
     }
     return TRUE;

--- a/tests/testthat/test_anyMissing.R
+++ b/tests/testthat/test_anyMissing.R
@@ -93,3 +93,18 @@ test_that("anyMissing and allMissing work correctly with data.frames", {
   expect_true(allMissing(df))
   expect_false(all(vlapply(df, allMissing)))
 })
+
+test_that("anyMissing and allMissing work correctly with complex numbers where one part is only NA", {
+  xc = 2 + 2i
+  expect_false(anyMissing(xc))
+  expect_false(allMissing(xc))
+
+  xc = NA + 2i
+  expect_true(anyMissing(xc))
+  expect_true(allMissing(xc))
+
+  xc = complex(1, 2, NA)
+  expect_equal(Re(xc), 2)
+  expect_true(anyMissing(xc))
+  expect_true(allMissing(xc))
+})


### PR DESCRIPTION
The logic was incorrect here for allMissing in cases where the either the real or imaginary part were missing while the other was not missing.