### PR TITLE
Reversed set assert message for clarity when dealing with long sets a…

### DIFF
--- a/R/helper.R
+++ b/R/helper.R
@@ -64,8 +64,8 @@ check_subset_internal = function(x, choices, match, what = NULL) {
     ii = match(x, choices)
     if (anyMissing(ii)) {
       return(set_msg(
-        "must be a subset of %s, but has additional elements %s",
-        what, set_collapse(choices), set_collapse(x[is.na(ii)])
+        "has additional elements %s, but must be a subset of %s",
+        what, set_collapse(x[is.na(ii)]), set_collapse(choices)
       ))
     }
   }


### PR DESCRIPTION
When dealing with sets with a lot of elements, the error message gets truncated and the most important piece of information to the user is lost. This patch fixes that.

Reproducible example:

```
data <- data.frame(x = 1:5, X = TRUE)
myset <- c(letters, outer(letters, letters, paste0))
coll <- checkmate::makeAssertCollection()
checkmate::assert_subset(x = names(data), 
                         choices = myset, 
                         add = coll)
checkmate::reportAssertions(coll)
```

https://github.com/vubiostat/redcapAPI/issues/471