### PR TITLE
Fix: find_missing_integerish() handles complex type

### DIFF
--- a/src/any_missing.c
+++ b/src/any_missing.c
@@ -34,7 +34,8 @@ R_xlen_t attribute_hidden find_missing_integerish(SEXP x) {
         case LGLSXP: return find_missing_logical(x);
         case INTSXP: return find_missing_integer(x);
         case REALSXP: return find_missing_double(x);
-        default: error("Error in find_missing_integerish: x must be logical or numeric");
+        case CPLXSXP: return find_missing_complex(x);
+        default: error("Error in find_missing_integerish: x must be logical, numeric, or complex");
     }
 }
 

--- a/tests/testthat/test_qassert.R
+++ b/tests/testthat/test_qassert.R
@@ -75,6 +75,8 @@ test_that("integerish", {
   expect_fail_all(xi, "X")
   expect_succ_all(xr, "x")
   expect_fail_all(xr, "X")
+  expect_succ_all(xc, "x")
+  expect_fail_all(xc, "X")
   expect_fail_all(1:3+.0001, "x")
   expect_fail_all(xd, "x")
 })


### PR DESCRIPTION
Calling `qtest()`, `qassert()`, or `qexpect()` with `rules = "X"` on an object of complex type that passes the integerish check will throw an internal error from `find_missing_integerish()` because it is missing a case for `CPLXSXP`.

### Example
``` r
qtest(0+1i, "x")
#> [1] FALSE
qtest(0+0i, "x")
#> [1] TRUE
qtest(NA_complex_, "x")
#> [1] TRUE
qtest(0+1i, "X")
#> [1] FALSE
qtest(0+0i, "X")
#> Error in checkmate::qtest(0 + (0+0i), "X"): Error in find_missing_integerish: x must be logical or numeric
qtest(NA_complex_, "X")
#> Error in checkmate::qtest(NA_complex_, "X"): Error in find_missing_integerish: x must be logical or numeric
```
### Corrected
``` r
qtest(0+1i, "x")
#> [1] FALSE
qtest(0+0i, "x")
#> [1] TRUE
qtest(NA_complex_, "x")
#> [1] TRUE
qtest(0+1i, "X")
#> [1] FALSE
qtest(0+0i, "X")
#> [1] TRUE
qtest(NA_complex_, "X")
#> [1] FALSE
```
<sup>Created on 2026-01-29 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>