### PR TITLE
fix: reject Date and POSIXt in is_class_numeric

### DIFF
--- a/src/helper.c
+++ b/src/helper.c
@@ -110,7 +110,7 @@ Rboolean is_class_integer(SEXP x) { return isInteger(x); }
 Rboolean is_class_integerish(SEXP x) { return isIntegerish(x, INTEGERISH_DEFAULT_TOL, TRUE); }
 Rboolean is_class_numeric(SEXP x) {
     switch(TYPEOF(x)) {
-        case REALSXP: return TRUE;
+        case REALSXP: return !(inherits(x, "Date") || inherits(x, "POSIXt"));
         case INTSXP: return !inherits(x, "factor");
     }
     return FALSE;

--- a/tests/testthat/test_checkNumber.R
+++ b/tests/testthat/test_checkNumber.R
@@ -11,6 +11,8 @@ test_that("checkNumber", {
 
   expect_false(testNumber(TRUE))
   expect_false(testNumber(FALSE))
+  expect_false(testNumber(as.Date("2000-01-01")))
+  expect_false(testNumber(as.POSIXct("2000-01-01")))
   expect_true(testNumber(1L))
   expect_true(testNumber(1.))
   expect_false(testNumber(NA))

--- a/tests/testthat/test_checkNumeric.R
+++ b/tests/testthat/test_checkNumeric.R
@@ -10,6 +10,8 @@ test_that("checkNumeric", {
   expect_false(testNumeric(NULL))
   expect_false(testNumeric(TRUE))
   expect_false(testNumeric(FALSE))
+  expect_false(testNumeric(as.Date("2000-01-01")))
+  expect_false(testNumeric(as.POSIXct("2000-01-01")))
   expect_true(testNumeric(NA_character_))
   expect_true(testNumeric(NA_real_))
   expect_true(testNumeric(NaN))


### PR DESCRIPTION
closes: https://github.com/mllg/checkmate/issues/275