### PR TITLE
perf: use `==` instead of `identical()` for typeof comparison in isSameType()

### DIFF
--- a/R/helper.R
+++ b/R/helper.R
@@ -20,7 +20,7 @@ guessType = function(x) {
 }
 
 isSameType = function(x, y) {
-  identical(typeof(x), typeof(y)) || (is.numeric(x) && is.numeric(y))
+  typeof(x) == typeof(y) || (is.numeric(x) && is.numeric(y))
 }
 
 array_collapse = function(x) {


### PR DESCRIPTION
`typeof()` always returns a string w/o attributes