### PR TITLE
fix: infinite loop in is_sorted_character with leading NA

### DIFF
--- a/src/is_sorted.c
+++ b/src/is_sorted.c
@@ -57,6 +57,7 @@ static Rboolean is_sorted_character(SEXP x) {
         xi = STRING_ELT(x, i);
         if (xi != NA_STRING)
             break;
+        i++;
     }
 
     for (R_xlen_t j = i + 1; j < n; j++) {


### PR DESCRIPTION
The leading NA scan in is_sorted_character was missing an increment, hence `checkCharacter(x, sorted = TRUE)` hung forever whenever x[1] was NA.